### PR TITLE
Fixed url in the Cloud9 dev

### DIFF
--- a/deployment/dev_environment_cloud9/cfn/cloud9-htc-grid.yaml
+++ b/deployment/dev_environment_cloud9/cfn/cloud9-htc-grid.yaml
@@ -300,7 +300,7 @@ Resources:
             - sudo growpart /dev/xvda 1
             - sudo resize2fs $(df -h |awk '/^\/dev/{print $1}')
             - echo "=== Downloading HTC-Grid project ==="
-            - curl --silent --location -o /home/ec2-user/environment/aws-htc-grid.tar.gz "https://github.com/awslabs/aws-htc-grid/releases/download/v0.1.0/aws-htc-grid.tar.gz"
+            - curl --silent --location -o /home/ec2-user/environment/aws-htc-grid.tar.gz "https://github.com/awslabs/aws-htc-grid/archive/refs/tags/v0.1.0.tar.gz"
             - cd /home/ec2-user/environment; tar xzvf aws-htc-grid.tar.gz
             - sudo chown -R 501:501 /home/ec2-user/environment/
   C9BootstrapAssociation:


### PR DESCRIPTION
The URL within the config file for Cloud and point it to the right
initial release at : https://github.com/awslabs/aws-htc-grid/archive/refs/tags/v0.1.0.tar.gz

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
