### PR TITLE
Compliance with terraform 0.15.0 and new example added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ serve: import
 import: packages $(PACKAGES)
 	pip install --force-reinstall $(PACKAGES)
 
-upload-c++:
+upload-c++: config-c++
 	$(MAKE) -C ./examples/workloads/c++/mock_computation upload
 
-upload-python:
+upload-python: config-python
 	$(MAKE) -C ./examples/workloads/python/mock_computation upload
 
 config-c++:
@@ -74,6 +74,8 @@ config-c++:
 config-python:
 	$(MAKE) -C ./examples/configurations generated-python
 
+config-s3-c++:
+	$(MAKE) -C ./examples/configurations generated-s3-c++
 
 happy-path: all upload-c++ config-c++
 

--- a/deployment/grid/terraform/providers.tf
+++ b/deployment/grid/terraform/providers.tf
@@ -13,11 +13,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.35"
+      version = "~> 3.37"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0.3"
+      version = "~> 2.1.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/deployment/grid/terraform/resources/eks_cluster.tf
+++ b/deployment/grid/terraform/resources/eks_cluster.tf
@@ -28,7 +28,7 @@ resource "helm_release" "eks-charts" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "14.0.0"
+  version = "15.1.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version

--- a/deployment/grid/terraform/resources/outputs.tf
+++ b/deployment/grid/terraform/resources/outputs.tf
@@ -16,6 +16,7 @@ output "certificate_authority" {
 output "token" {
   description = "authentication token for EKS"
   value       = data.aws_eks_cluster_auth.cluster.token
+  sensitive   = true
 }
 
 

--- a/deployment/grid/terraform/scheduler/api-gateway-private.tf
+++ b/deployment/grid/terraform/scheduler/api-gateway-private.tf
@@ -127,11 +127,11 @@ resource "aws_api_gateway_deployment" "htc_grid_private_deployment" {
   depends_on = [aws_api_gateway_method.htc_grid_private_submit_proxy_method,aws_api_gateway_method.htc_grid_private_result_proxy_method]
   rest_api_id = aws_api_gateway_rest_api.htc_grid_private_rest_api.id
   triggers = {
-    redeployment = sha1(join(",", list(
+    redeployment = sha1(join(",", tolist([
     jsonencode(aws_api_gateway_integration.htc_grid_private_submit_proxy_integration),
     jsonencode(aws_api_gateway_integration.htc_grid_private_result_proxy_integration),
     jsonencode(aws_api_gateway_integration.htc_grid_private_cancel_proxy_integration)
-    )))
+    ])))
   }
 
   stage_name = var.api_gateway_version

--- a/deployment/grid/terraform/scheduler/api-gateway-public.tf
+++ b/deployment/grid/terraform/scheduler/api-gateway-public.tf
@@ -95,11 +95,11 @@ resource "aws_api_gateway_deployment" "htc_grid_public_deployment" {
   depends_on = [aws_api_gateway_method.htc_grid_public_submit_proxy_method,aws_api_gateway_method.htc_grid_public_result_proxy_method]
   rest_api_id = aws_api_gateway_rest_api.htc_grid_public_rest_api.id
   triggers = {
-    redeployment = sha1(join(",", list(
+    redeployment = sha1(join(",", tolist([
       jsonencode(aws_api_gateway_integration.htc_grid_public_submit_proxy_integration),
       jsonencode(aws_api_gateway_integration.htc_grid_public_result_proxy_integration),
       jsonencode(aws_api_gateway_integration.htc_grid_public_cancel_proxy_integration)
-    )))
+    ])))
   }
 
   stage_name = var.api_gateway_version

--- a/deployment/grid/terraform/scheduler/outputs.tf
+++ b/deployment/grid/terraform/scheduler/outputs.tf
@@ -23,4 +23,5 @@ output "private_api_gateway_url" {
 
 output "api_gateway_key" {
   value = aws_api_gateway_api_key.htc_grid_api_key.value
+  sensitive = true
 }

--- a/deployment/grid/terraform/scheduler/s3.tf
+++ b/deployment/grid/terraform/scheduler/s3.tf
@@ -5,4 +5,5 @@
 resource "aws_s3_bucket" "htc-stdout-bucket" {
   bucket_prefix = var.s3_bucket
   acl    = "private"
+  force_destroy = true
 }

--- a/examples/configurations/Makefile
+++ b/examples/configurations/Makefile
@@ -11,8 +11,14 @@ FUNCTION_HANDLER=
 ACCOUNT_ID?=$(shell aws sts get-caller-identity | jq -r '.Account')
 
 
+
+
 generated-c++: grid_config.json.tpl
 	mkdir -p $(GENERATED) && cat grid_config.json.tpl | sed "s/{{region}}/$(REGION)/;s/{{workload_bucket_name}}/$(BUCKET_NAME)/;s/{{image_tag}}/$(TAG)/;s/{{account_id}}/${ACCOUNT_ID}/" > $(GENERATED)/grid_config.json
+
+generated-s3-c++: custom_runtime_s3_grid_config.json.tpl
+	mkdir -p $(GENERATED) && cat custom_runtime_s3_grid_config.json.tpl | sed "s/{{region}}/$(REGION)/;s/{{workload_bucket_name}}/$(BUCKET_NAME)/;s/{{image_tag}}/$(TAG)/;s/{{account_id}}/${ACCOUNT_ID}/" > $(GENERATED)/custom_runtime_s3_grid_config.json
+
 
 generated-python: python_runtime_grid_config.json.tpl
 	mkdir -p $(GENERATED) && cat python_runtime_grid_config.json.tpl | sed "s/{{python_file_handler}}/$(FILE_HANDLER)/;s/{{python_function_handler}}/$(FUNCTION_HANDLER)/;s/{{region}}/$(REGION)/;s/{{workload_bucket_name}}/$(BUCKET_NAME)/;s/{{image_tag}}/$(TAG)/;s/{{account_id}}/${ACCOUNT_ID}/" > $(GENERATED)/python_runtime_grid_config.json

--- a/examples/configurations/custom_runtime_s3_grid_config.json.tpl
+++ b/examples/configurations/custom_runtime_s3_grid_config.json.tpl
@@ -1,0 +1,50 @@
+{
+  "region": "{{region}}",
+  "project_name": "{{image_tag}}",
+  "grid_storage_service" : "S3",
+  "max_htc_agents": 100,
+  "min_htc_agents": 1,
+  "dynamodb_default_read_capacity" : 10,
+  "dynamodb_default_write_capacity" : 10,
+  "eks_worker_groups" : [
+      {
+        "name"                    : "worker-small-spot",
+        "override_instance_types" : ["m5.xlarge","m4.xlarge","m5d.xlarge","m5a.xlarge"],
+        "spot_instance_pools"     : 0,
+        "asg_min_size"            : 0,
+        "asg_max_size"            : 3,
+        "asg_desired_capacity"    : 1,
+        "on_demand_base_capacity" : 0
+      },
+      {
+        "name"                    : "worker-medium-spot",
+        "override_instance_types" : ["m5.2xlarge","m5d.2xlarge", "m5a.2xlarge","m4.2xlarge"],
+        "spot_instance_pools"     : 0,
+        "asg_min_size"            : 0,
+        "asg_max_size"            : 3,
+        "asg_desired_capacity"    : 0,
+        "on_demand_base_capacity" : 0
+
+      }
+  ],
+  "agent_configuration": {
+    "lambda": {
+      "minCPU": "800",
+      "maxCPU": "900",
+      "minMemory": "1200",
+      "maxMemory": "1900",
+      "location" : "s3://{{workload_bucket_name}}/lambda.zip",
+      "runtime": "provided"
+    }
+  },
+  "enable_private_subnet" : true,
+  "vpc_cidr_block_public" :["10.0.192.0/24", "10.0.193.0/24", "10.0.194.0/24"],
+  "vpc_cidr_block_private" :["10.0.0.0/18","10.0.64.0/18", "10.0.128.0/18"],
+  "input_role":[
+      {
+        "rolearn"  : "arn:aws:iam::{{account_id}}:role/Admin",
+        "username" : "lambda",
+        "groups"   : ["system:masters"]
+      }
+  ]
+}

--- a/examples/workloads/python/mock_computation/mock_compute_engine.py
+++ b/examples/workloads/python/mock_computation/mock_compute_engine.py
@@ -8,6 +8,4 @@ def lambda_handler(event, context):
     message = 'Hellrint(args[0]) {}!'.format(event)
     args = event['worker_arguments']
     time.sleep(int(args[0])/1000)
-    return {
-        'message' : message
-    }
+    return int(args[0])


### PR DESCRIPTION
### Description
#### Fix:
- Make sure s3 bucket is deleted by terraform even if not empty
- Change the return value of the python workload so it matches what is expected by the client.py

#### Feature
- Adding a config files example for data plane back by an S3 bucket
- Compliance with terraform 0.15.0


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [x] Backfilled missing tests for code in same general area
- [ ] Refactored something and made the world a better place
