### PR TITLE
fix: string validation improved for cognito domain name

### DIFF
--- a/deployment/grid/terraform/resources/auth.tf
+++ b/deployment/grid/terraform/resources/auth.tf
@@ -57,6 +57,6 @@ resource "null_resource" "modify_ingress" {
 
 
 resource "aws_cognito_user_pool_domain" "domain" {
-  domain       = "${lower(var.suffix)}-${random_string.random_resources.result}"
+  domain       = replace("${lower(var.suffix)}-${random_string.random_resources.result}","aws","")
   user_pool_id = aws_cognito_user_pool.htc_pool.id
 }


### PR DESCRIPTION
### Description

Fix domaine name associated with Cognito User Pool (removing substring `aws` because this is not allowed)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [ ] Refactored something and made the world a better place
