### PR TITLE
Fixed Prometheus version

### DIFF
--- a/deployment/grid/terraform/variables.tf
+++ b/deployment/grid/terraform/variables.tf
@@ -372,10 +372,10 @@ variable "prometheus_configuration" {
 
   })
   default = {
-    node_exporter_tag = "v1.0.1"
-    server_tag = "v2.24.0"
-    alertmanager_tag = "v0.21.0"
-    kube_state_metrics_tag = "v1.9.8"
+    node_exporter_tag = "v1.1.2"
+    server_tag = "v2.26.0"
+    alertmanager_tag = "v0.22.0"
+    kube_state_metrics_tag = "v2.0.0"
     pushgateway_tag = "v1.3.1"
     configmap_reload_tag = "v0.5.0"
   }

--- a/deployment/image_repository/terraform/images_config.json
+++ b/deployment/image_repository/terraform/images_config.json
@@ -11,7 +11,7 @@
         "grafana/grafana:7.4.2" :"grafana",
         "chankh/k8s-cloudwatch-adapter:v0.8.0" :"k8s-cloudwatch-adapter",
         "kiwigrid/k8s-sidecar:1.10.7" :"k8s-sidecar",
-        "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8" :"kube-state-metrics",
+        "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0" :"kube-state-metrics",
         "quay.io/prometheus/node-exporter:v1.1.2" :"node-exporter",
         "quay.io/prometheus/prometheus:v2.26.0" :"prometheus",
         "prom/pushgateway:v1.3.1" :"pushgateway",

--- a/deployment/image_repository/terraform/images_config.json
+++ b/deployment/image_repository/terraform/images_config.json
@@ -1,6 +1,6 @@
 { 
     "image_to_copy": {
-        "quay.io/prometheus/alertmanager:v0.21.0" :"alertmanager" ,
+        "quay.io/prometheus/alertmanager:v0.22.1" :"alertmanager" ,
         "amazon/aws-node-termination-handler:v1.10.0" :"amazon/aws-node-termination-handler",
         "amazon/cloudwatch-agent:1.247347.5b250583" :"amazon/cloudwatch-agent",
         "busybox:latest" :"busybox",
@@ -12,8 +12,8 @@
         "chankh/k8s-cloudwatch-adapter:v0.8.0" :"k8s-cloudwatch-adapter",
         "kiwigrid/k8s-sidecar:1.10.7" :"k8s-sidecar",
         "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8" :"kube-state-metrics",
-        "quay.io/prometheus/node-exporter:v1.0.1" :"node-exporter",
-        "quay.io/prometheus/prometheus:v2.24.0" :"prometheus",
+        "quay.io/prometheus/node-exporter:v1.1.2" :"node-exporter",
+        "quay.io/prometheus/prometheus:v2.26.0" :"prometheus",
         "prom/pushgateway:v1.3.1" :"pushgateway",
         "influxdb:1.8.0-alpine" :"influxdb",
         "amazon/aws-xray-daemon:latest" :"aws-xray-daemon",


### PR DESCRIPTION
### Description

There have been a few changes to the helm prometheus version. Some of them were incompatible with the versions that we we were using.  The `terraform/variables.tf` and the images in the image repository for `alertmanager`, `kube-state-metrics`, `node-exporter` and `prometheus` have been updated to the latest version as in the ones used in master and the latest version for https://github.com/prometheus-community/helm-charts. Then tested. There might be some changes required in the Dashboards given the change in metrics but all is working back well.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [ ] Refactored something and made the world a better place
