### PR TITLE
Upstream Influxdb Helm Chart got Updated 

### DIFF
--- a/deployment/image_repository/terraform/images_config.json
+++ b/deployment/image_repository/terraform/images_config.json
@@ -15,7 +15,7 @@
         "quay.io/prometheus/node-exporter:v1.1.2":"node-exporter",
         "quay.io/prometheus/prometheus:v2.26.0":"prometheus",
         "prom/pushgateway:v1.3.1":"pushgateway",
-        "influxdb:1.8.0-alpine":"influxdb",
+        "influxdb:1.8.6-alpine":"influxdb",
         "amazon/aws-xray-daemon:latest":"aws-xray-daemon",
         "lambci/lambda:provided": "lambda",
         "lambci/lambda:python3.8": "lambda",


### PR DESCRIPTION
### Description


In the first terraform apply we need to run for creating ECR Images we are pushing influxdb:1.8.0-alpine to ECR repo. However influxdb helm chart thats released as a part of second terraform apply refers to influxdb:1.8.6-alpine due to change they made yesterday https://github.com/influxdata/helm-charts/blob/master/charts/influxdb/values.yaml 

As a result of us maintaining older version in ECR - influxdb pods are ending up in ErrImagePull state and therefore rest of terraform apply fails

This PR is to change tag for influxdb image from "1.8.0-alpine" to "1.8.6-alpine" in images_config.json 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [x] Refactored something and made the world a better place
