### PR TITLE
Cancel tasks that are in processing state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTC-Grid
+# HTC-Grid 
 The high throughput compute grid project (HTC-Grid) is a container based cloud native HPC/Grid environment. The project provides a reference architecture that can be used to build and adapt a modern High throughput compute solution using underlying AWS services, allowing users to submit high volumes of short and long running tasks and scaling environments dynamically.
 
 **Warning**: This project is an Open Source (Apache 2.0 License), not a supported AWS Service offering.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTC-Grid 
+# HTC-Grid  
 The high throughput compute grid project (HTC-Grid) is a container based cloud native HPC/Grid environment. The project provides a reference architecture that can be used to build and adapt a modern High throughput compute solution using underlying AWS services, allowing users to submit high volumes of short and long running tasks and scaling environments dynamically.
 
 **Warning**: This project is an Open Source (Apache 2.0 License), not a supported AWS Service offering.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTC-Grid  
+# HTC-Grid
 The high throughput compute grid project (HTC-Grid) is a container based cloud native HPC/Grid environment. The project provides a reference architecture that can be used to build and adapt a modern High throughput compute solution using underlying AWS services, allowing users to submit high volumes of short and long running tasks and scaling environments dynamically.
 
 **Warning**: This project is an Open Source (Apache 2.0 License), not a supported AWS Service offering.

--- a/docs/project/api/client/python/reference.md
+++ b/docs/project/api/client/python/reference.md
@@ -4,7 +4,7 @@
 
 This section outlines how client application can connect and interact with a deployed HTC-Grid.
 
-AWSConnector is the main class responsible for communication with the HTC-Grid. Upon creating the 
+AWSConnector is the main class responsible for communication with the HTC-Grid. Upon creating the
 
 ```python
 class api.connector.AWSConnector
@@ -248,7 +248,7 @@ Function returns dictionary of processed session IDs.
 ```
 
 * `string` - keys of the response dictionary are session IDs that were passed in for cancellation. Sub-dictionaries contain information about how many tasks were moved into canceled state.
-   * `cancellet_retying` - number of tasks moved from retrying state into canceled state
-   * `cancellet_pending` - number of tasks moved from pending state into canceled state
-   * `cancellet_processing` - number of tasks moved from processing state into canceled state. **Note**, in current version, while state of tasks has been moved into canceled processing will not be preemptively terminated (processing will continue until task is completed or failed). Failed tasks will not be retried.
-   * `tatal_cancelled_tasks` - total number of tasks that has been affected by this invocation.
+   * `cancelled_retying` - number of tasks moved from retrying state into canceled state
+   * `cancelled_pending` - number of tasks moved from pending state into canceled state
+   * `cancelled_processing` - number of tasks moved from the processing state into canceled state.
+   * `total_cancelled_tasks` - total number of tasks that has been affected by this invocation.

--- a/examples/submissions/k8s_jobs/Dockerfile.Submitter
+++ b/examples/submissions/k8s_jobs/Dockerfile.Submitter
@@ -12,6 +12,7 @@ RUN pip install -r requirements.txt
 
 COPY ./examples/client/python/client.py .
 COPY ./examples/client/python/simple_client.py .
+COPY ./examples/client/python/cancel_tasks.py .
 COPY ./examples/client/python/portfolio_pricing_client.py .
 COPY ./examples/client/python/sample_portfolio.json .
 

--- a/examples/submissions/k8s_jobs/Makefile
+++ b/examples/submissions/k8s_jobs/Makefile
@@ -25,5 +25,9 @@ generated:
 
 	mkdir -p $(GENERATED) && cat portfolio-pricing-book.yaml.tpl | sed "s/{{account_id}}/$(ACCOUNT_ID)/;s/{{region}}/$(REGION)/;s/{{image_name}}/$(SUBMITTER_IMAGE_NAME)/;s/{{image_tag}}/$(TAG)/" > $(GENERATED)/portfolio-pricing-book.yaml
 
+	mkdir -p $(GENERATED) && cat cancel-many-small-tasks-test.yaml.tpl | sed "s/{{account_id}}/$(ACCOUNT_ID)/;s/{{region}}/$(REGION)/;s/{{image_name}}/$(SUBMITTER_IMAGE_NAME)/;s/{{image_tag}}/$(TAG)/" > $(GENERATED)/cancel-many-small-tasks-test.yaml
+
+	mkdir -p $(GENERATED) && cat cancel-one-long-task-test.yaml.tpl | sed "s/{{account_id}}/$(ACCOUNT_ID)/;s/{{region}}/$(REGION)/;s/{{image_name}}/$(SUBMITTER_IMAGE_NAME)/;s/{{image_tag}}/$(TAG)/" > $(GENERATED)/cancel-one-long-task-test.yaml
+
 clean:
 	rm -rf $(GENERATED)

--- a/examples/submissions/k8s_jobs/cancel-many-small-tasks-test.yaml.tpl
+++ b/examples/submissions/k8s_jobs/cancel-many-small-tasks-test.yaml.tpl
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-cancel-many-small-tasks
+spec:
+  template:
+    spec:
+      containers:
+      - name: generator
+        securityContext:
+            {}
+        image: {{account_id}}.dkr.ecr.{{region}}.amazonaws.com/{{image_name}}:{{image_tag}}
+        imagePullPolicy: Always
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        command: ["python3","./cancel_tasks.py", "--test_cancel_many_small_tasks", "1"]
+        volumeMounts:
+          - name: agent-config-volume
+            mountPath: /etc/agent
+        env:
+          - name: INTRA_VPC
+            value: "1"
+      restartPolicy: Never
+      nodeSelector:
+        grid/type: Operator
+      tolerations:
+      - effect: NoSchedule
+        key: grid/type
+        operator: Equal
+        value: Operator
+      volumes:
+        - name: agent-config-volume
+          configMap:
+            name: agent-configmap
+  backoffLimit: 0

--- a/examples/submissions/k8s_jobs/cancel-one-long-task-test.yaml.tpl
+++ b/examples/submissions/k8s_jobs/cancel-one-long-task-test.yaml.tpl
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-cancel-one-long-task
+spec:
+  template:
+    spec:
+      containers:
+      - name: generator
+        securityContext:
+            {}
+        image: {{account_id}}.dkr.ecr.{{region}}.amazonaws.com/{{image_name}}:{{image_tag}}
+        imagePullPolicy: Always
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        command: ["python3","./cancel_tasks.py", "--test_cancel_one_long_task", "1"]
+        volumeMounts:
+          - name: agent-config-volume
+            mountPath: /etc/agent
+        env:
+          - name: INTRA_VPC
+            value: "1"
+      restartPolicy: Never
+      nodeSelector:
+        grid/type: Operator
+      tolerations:
+      - effect: NoSchedule
+        key: grid/type
+        operator: Equal
+        value: Operator
+      volumes:
+        - name: agent-config-volume
+          configMap:
+            name: agent-configmap
+  backoffLimit: 0

--- a/source/client/python/api-v0.1/api/connector.py
+++ b/source/client/python/api-v0.1/api/connector.py
@@ -388,13 +388,13 @@ class AWSConnector:
                 "cancelled_retrying": 0,
                 "cancelled_pending": 5,
                 "cancelled_processing": 1,
-                "tatal_cancelled_tasks": 6
+                "total_cancelled_tasks": 6
             },
             "6398f57e-6911-11eb-b5fb-060372291b89-part024": {
                 "cancelled_retrying": 0,
                 "cancelled_pending": 9,
                 "cancelled_processing": 0,
-                "tatal_cancelled_tasks": 9
+                "total_cancelled_tasks": 9
             }
         }
 

--- a/source/control_plane/openapi/private/api_definition.yaml
+++ b/source/control_plane/openapi/private/api_definition.yaml
@@ -28,7 +28,8 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                type: object
+                $ref: '#/components/schemas/PostCancelResponse'
         542:
           description: Invalid status value
           content: { }
@@ -149,3 +150,5 @@ components:
             type: string
         session_id:
           type: string
+    PostCancelResponse:
+      type: object

--- a/source/control_plane/openapi/public/api_definition.yaml
+++ b/source/control_plane/openapi/public/api_definition.yaml
@@ -28,7 +28,8 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                type: object
+                $ref: '#/components/schemas/PostCancelResponse'
         542:
           description: Invalid status value
           content: { }
@@ -154,3 +155,5 @@ components:
             type: string
         session_id:
           type: string
+    PostCancelResponse:
+      type: object

--- a/source/control_plane/python/lambda/get_results/get_results.py
+++ b/source/control_plane/python/lambda/get_results/get_results.py
@@ -37,10 +37,17 @@ def get_time_now_ms():
 def get_tasks_statuses_in_session(session_id):
 
     assert(session_id is not None)
-    response = {}
+    response = {
+        "finished": [],
+        "finished_OUTPUT": [],
+        "cancelled": [],
+        "cancelled_OUTPUT": [],
+        "failed": [],
+        "failed_OUTPUT": []
+    }
 
     # <1.> Process finished Tasks
-    finished_tasks_resp = state_table.get_tasks_by_status(session_id, TASK_STATE_FINISHED)
+    finished_tasks_resp = state_table.get_tasks_by_state(session_id, TASK_STATE_FINISHED)
 
     finished_tasks = finished_tasks_resp["Items"]
     if len(finished_tasks) > 0:
@@ -48,7 +55,7 @@ def get_tasks_statuses_in_session(session_id):
         response[TASK_STATE_FINISHED + '_OUTPUT'] = ["read_from_dataplane" for x in finished_tasks]
 
     # <2.> Process cancelled Tasks
-    cancelled_tasks_resp = state_table.get_tasks_by_status(session_id, TASK_STATE_CANCELLED)
+    cancelled_tasks_resp = state_table.get_tasks_by_state(session_id, TASK_STATE_CANCELLED)
 
     cancelled_tasks = cancelled_tasks_resp["Items"]
     if len(cancelled_tasks) > 0:
@@ -56,7 +63,7 @@ def get_tasks_statuses_in_session(session_id):
         response[TASK_STATE_CANCELLED + '_OUTPUT'] = ["read_from_dataplane" for x in cancelled_tasks]
 
     # <3.> Process failed Tasks
-    failed_tasks_resp = state_table.get_tasks_by_status(session_id, TASK_STATE_FAILED)
+    failed_tasks_resp = state_table.get_tasks_by_state(session_id, TASK_STATE_FAILED)
 
     failed_tasks = failed_tasks_resp["Items"]
     if len(failed_tasks) > 0:


### PR DESCRIPTION
### Description

Cancel session will now cancel tasks that are in the processing state (i.e., executing by worker lambda functions). 
Using periodic heartbeat checks, Agent detects that its task has been cancelled. 
The task is removed from the task queue, then pod running the agent is restarted (without waiting for the task to be completed)  

Also, some refactoring + fixes around OpenAPI for cancel requests.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [x] Refactored something and made the world a better place
