### PR TITLE
Callback implementation for Python GCL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTC-Grid
+# HTC-Grid 
 The high throughput compute grid project (HTC-Grid) is a container based cloud native HPC/Grid environment. The project provides a reference architecture that can be used to build and adapt a modern High throughput compute solution using underlying AWS services, allowing users to submit high volumes of short and long running tasks and scaling environments dynamically.
 
 **Warning**: This project is an Open Source (Apache 2.0 License), not a supported AWS Service offering.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTC-Grid 
+# HTC-Grid  
 The high throughput compute grid project (HTC-Grid) is a container based cloud native HPC/Grid environment. The project provides a reference architecture that can be used to build and adapt a modern High throughput compute solution using underlying AWS services, allowing users to submit high volumes of short and long running tasks and scaling environments dynamically.
 
 **Warning**: This project is an Open Source (Apache 2.0 License), not a supported AWS Service offering.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTC-Grid  
+# HTC-Grid
 The high throughput compute grid project (HTC-Grid) is a container based cloud native HPC/Grid environment. The project provides a reference architecture that can be used to build and adapt a modern High throughput compute solution using underlying AWS services, allowing users to submit high volumes of short and long running tasks and scaling environments dynamically.
 
 **Warning**: This project is an Open Source (Apache 2.0 License), not a supported AWS Service offering.

--- a/examples/client/python/simple_client_v2.py
+++ b/examples/client/python/simple_client_v2.py
@@ -1,0 +1,108 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 https://aws.amazon.com/apache-2-0/
+
+from api.connector import HTCGridConnector
+from api.session import GridSession
+
+import time
+import os
+import json
+import logging
+
+try:
+    client_config_file = os.environ['AGENT_CONFIG_FILE']
+except:
+    client_config_file = "/etc/agent/Agent_config.tfvars.json"
+
+with open(client_config_file, 'r') as file:
+    client_config_file = json.loads(file.read())
+
+
+TOTAL_COUNT = 0
+# Sample function callback
+def sample_callback(worker_lambda_response):
+    global TOTAL_COUNT
+    TOTAL_COUNT += 1
+    print(f"{TOTAL_COUNT}\tOK: {worker_lambda_response}")
+
+    # do some computation
+
+    pass
+
+if __name__ == "__main__":
+
+    logging.info("Simple Client V2")
+    try:
+        username = os.environ['USERNAME']
+    except KeyError:
+        username = ""
+    try:
+        password = os.environ['PASSWORD']
+    except KeyError:
+        password = ""
+
+
+    # <1.> Establishes connection to one of many available HTC-Grids
+    grid_connector = HTCGridConnector(client_config_file, username=username, password=password)
+
+    # <2.> Authentication based on the configuration file above
+    grid_connector.authenticate()
+
+
+    # <3.> Create session object with corresponding context & callback
+    context = {
+        "session_priority" : 1
+    }
+
+    grid_session = grid_connector.create_session(
+        service_name="MyService1",
+        context=context,
+        callback=sample_callback)
+
+
+    grid_session_2 = grid_connector.create_session(
+        service_name="MyService1",
+        context=context,
+        callback=sample_callback)
+
+
+    # <4.> Submit tasks for the session
+    task_1_definition = {
+        "worker_arguments": ["1000", "1", "1"]
+    }
+
+    task_2_definition = {
+        "worker_arguments": ["2000", "1", "1"]
+    }
+
+    grid_session.send([task_1_definition, task_2_definition])
+
+    grid_session_2.send([task_1_definition, task_2_definition])
+
+    # <5.> Submit additional tasks within the same session
+    time.sleep(1)
+    grid_session.send([task_1_definition, task_2_definition])
+
+    grid_session_2.send([task_1_definition, task_2_definition])
+
+
+    # Blocking wait for completion
+    grid_session.wait_for_completion(timeout_ms=3000)
+
+    print(grid_session.submitted_task_ids)
+
+    print(grid_session.received_task_ids)
+
+    grid_session.wait_for_completion()
+    grid_session_2.wait_for_completion()
+
+    # grid_session.cancel()
+
+    # Close session
+    grid_session.close()
+    grid_session_2.close()
+
+    # Close connector and stop thread
+    grid_connector.close(wait_for_sessions_completion=True)
+

--- a/examples/submissions/k8s_jobs/Dockerfile.Submitter
+++ b/examples/submissions/k8s_jobs/Dockerfile.Submitter
@@ -12,6 +12,7 @@ RUN pip install -r requirements.txt
 
 COPY ./examples/client/python/client.py .
 COPY ./examples/client/python/simple_client.py .
+COPY ./examples/client/python/simple_client_v2.py .
 COPY ./examples/client/python/portfolio_pricing_client.py .
 COPY ./examples/client/python/sample_portfolio.json .
 

--- a/examples/submissions/k8s_jobs/Makefile
+++ b/examples/submissions/k8s_jobs/Makefile
@@ -25,5 +25,7 @@ generated:
 
 	mkdir -p $(GENERATED) && cat portfolio-pricing-book.yaml.tpl | sed "s/{{account_id}}/$(ACCOUNT_ID)/;s/{{region}}/$(REGION)/;s/{{image_name}}/$(SUBMITTER_IMAGE_NAME)/;s/{{image_tag}}/$(TAG)/" > $(GENERATED)/portfolio-pricing-book.yaml
 
+	mkdir -p $(GENERATED) && cat simple-task-v2-test.yaml.tpl | sed "s/{{account_id}}/$(ACCOUNT_ID)/;s/{{region}}/$(REGION)/;s/{{image_name}}/$(SUBMITTER_IMAGE_NAME)/;s/{{image_tag}}/$(TAG)/" > $(GENERATED)/simple-task-v2-test.yaml
+
 clean:
 	rm -rf $(GENERATED)

--- a/examples/submissions/k8s_jobs/simple-task-v2-test.yaml.tpl
+++ b/examples/submissions/k8s_jobs/simple-task-v2-test.yaml.tpl
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: simple-client-v2-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: generator
+        securityContext:
+            {}
+        image: {{account_id}}.dkr.ecr.{{region}}.amazonaws.com/{{image_name}}:{{image_tag}}
+        imagePullPolicy: Always
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        command: ["python3","./simple_client_v2.py"]
+        volumeMounts:
+          - name: agent-config-volume
+            mountPath: /etc/agent
+        env:
+          - name: INTRA_VPC
+            value: "1"
+      restartPolicy: Never
+      nodeSelector:
+        grid/type: Operator
+      tolerations:
+      - effect: NoSchedule
+        key: grid/type
+        operator: Equal
+        value: Operator
+      volumes:
+        - name: agent-config-volume
+          configMap:
+            name: agent-configmap
+  backoffLimit: 0

--- a/source/client/python/api-v0.1/api/session.py
+++ b/source/client/python/api-v0.1/api/session.py
@@ -1,0 +1,186 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 https://aws.amazon.com/apache-2-0/
+
+import time
+import logging
+import json
+import base64
+import traceback
+
+logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s - %(funcName)s  - %(lineno)d - %(message)s",
+                    datefmt='%H:%M:%S', level=logging.INFO)
+
+def get_time_now_ms():
+    return int(round(time.time() * 1000))
+
+class GridSession:
+
+    def __init__(self, htc_grid_connector, session_id, callback):
+
+        self.htc_grid_connector = htc_grid_connector
+        self.session_id = session_id
+
+        self.submitted_task_ids = []
+        self.submitted_tasks_count = 0
+
+        self.received_task_ids = {}
+
+        self.callback = callback
+        self.time_send_was_invoked_ms = 0
+
+        self.in_out_manager = htc_grid_connector.in_out_manager
+
+        # TODO: update constants
+        self.TASK_TIMEOUT_SEC = 3600
+        self.RETRY_COUNT = 5
+
+    def send(self, tasks):  # returns TaskID[]
+        """This method submits tasks to the HTC grid
+
+        Args:
+          tasks_list (list): the list of tasks to execute on the grid
+
+        Returns:
+          dict: the response from the endpoint of the HTC grid
+
+        """
+        try:
+            self.time_send_was_invoked_ms = get_time_now_ms()
+
+            # <1.> Generate Task IDs based on the Session ID and the index of each task.
+            logging.info(f"Sending {len(tasks)} tasks for session {self.session_id}")
+            new_task_ids = []
+
+            for i, t in enumerate(tasks):
+
+                task_index = i + self.submitted_tasks_count
+                task_id = self.__make_task_id_from_session_id(self.session_id, task_index)
+                new_task_ids.append(task_id)
+
+            # <2.> Upload tasks into the Data Plane
+            serialized_tasks = []
+
+            for i, t in enumerate(tasks):
+
+                data = json.dumps(t).encode('utf-8')
+
+                b64data = base64.b64encode(data)
+
+                self.in_out_manager.put_input_from_bytes(new_task_ids[i], b64data)
+
+                serialized_tasks.append(b64data)
+
+            # <3.> Construct submit_tasks Lambda invocation payload that will be passed via Data Plane
+            lambda_data_plane_payload = self.__construct_submit_tasks_lambda_invocation_payload(new_task_ids, serialized_tasks)
+            logging.info(f"lambda_data_plane_payload: {lambda_data_plane_payload}")
+
+            # <4.> Invoke Submit Tasks Lambda in Control Plane
+            json_response = self.htc_grid_connector.submit(lambda_data_plane_payload)
+            logging.info(f"Submit Tasks Lambda json_response = {json_response}")
+
+            # <5.> Bookkeeping
+            # TODO: check if submission is successful
+            self.submitted_tasks_count += len(tasks)
+            self.submitted_task_ids += new_task_ids
+
+            return json_response
+        except Exception as e:
+            print("Unexpected error in sending {} [{}]".format(
+            e, traceback.format_exc()))
+
+
+    def __construct_submit_tasks_lambda_invocation_payload(self, new_task_ids, serialized_tasks):
+        lambda_payload = {
+            "session_id": self.session_id,
+            "scheduler_data": {
+                "task_timeout_sec": self.TASK_TIMEOUT_SEC,
+                "retry_count": self.RETRY_COUNT,
+                "tstamp_api_grid_connector_ms": 0,
+                "tstamp_agent_read_from_sqs_ms": 0
+            },
+            "stats": {
+                "stage1_grid_api_01_task_creation_tstmp": {"label": " ", "tstmp": self.time_send_was_invoked_ms},
+                "stage1_grid_api_02_task_submission_tstmp": {"label": "upload_data_to_storage",
+                                                             "tstmp": get_time_now_ms()},
+
+                "stage2_sbmtlmba_01_invocation_tstmp": {"label": "grid_api_2_lambda_ms", "tstmp": 0},
+                "stage2_sbmtlmba_02_before_batch_write_tstmp": {"label": "task_construction_ms", "tstmp": 0},
+                # "stage2_sbmtlmba_03_invocation_over_tstmp":    {"label": "dynamo_db_submit_ms", "tstmp" : 0},
+
+                "stage3_agent_01_task_acquired_sqs_tstmp": {"label": "sqs_queuing_time_ms", "tstmp": 0},
+                "stage3_agent_02_task_acquired_ddb_tstmp": {"label": "ddb_task_claiming_time_ms", "tstmp": 0},
+
+                "stage4_agent_01_user_code_finished_tstmp": {"label": "user_code_exec_time_ms", "tstmp": 0},
+                "stage4_agent_02_S3_stdout_delivered_tstmp": {"label": "S3_stdout_upload_time_ms", "tstmp": 0}
+            },
+            "tasks_list": {
+                "tasks": new_task_ids if self.htc_grid_connector.is_task_input_passed_via_external_storage() == 1 else serialized_tasks
+            }
+        }
+
+        return lambda_payload
+
+
+    def check_tasks_states(self):
+        print(f"Session: Checking status {self.session_id}, submitted: {len(self.submitted_task_ids)}, received: {len(self.received_task_ids)}")
+
+        try:
+
+            res = self.htc_grid_connector.get_results(self.session_id)
+
+            # Process only task_ids that we haven't seen before.
+            for t in res["finished"]:
+                if t not in self.received_task_ids:
+
+                    self.received_task_ids[t] = True
+
+                    stdout_bytes = self.in_out_manager.get_output_to_bytes(t)
+                    logging.info("output_bytes: {}".format(stdout_bytes))
+
+                    output = base64.b64decode(stdout_bytes).decode('utf-8')
+                    logging.info("output_obj: {}".format(output))
+
+                    # TODO: check if success or failure
+
+                    self.callback(output)
+
+        except Exception as e:
+            print("Unexpected error in check_tasks_states {} [{}]".format(
+            e, traceback.format_exc()))
+
+
+    def wait_for_completion(self, timeout_ms=0, complete_and_close=False):
+        time_start_ms = get_time_now_ms()
+
+        while len(self.received_task_ids) < len(self.submitted_task_ids):
+            print("Session: Main thread sleeps for results")
+
+            time.sleep(1.0)
+
+            if 0 < timeout_ms < get_time_now_ms() - time_start_ms:
+                logging.warning(f"{__name__} timeoud after {timeout_ms}")
+                break
+
+        if len(self.received_task_ids) == len(self.submitted_task_ids):
+            # Unless more tasks will be submitted within this session
+            # Session can be considered completed.
+            if complete_and_close:
+                self.close()
+
+    def cancel(self):
+        self.htc_grid_connector.cancel_sessions([self.session_id])
+
+    def close(self):
+        self.htc_grid_connector.diregister_session(session=self)
+
+
+    def __make_task_id_from_session_id(self, session_id, task_index):
+        return f"{session_id}_{task_index}"
+
+    def __hash__(self):
+        return self.session_id
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)): return NotImplemented
+        return self.session_id == other.session_id


### PR DESCRIPTION
### Description

This is a draft for the Python Grid Connector Library with support of (client-based) callbacks. 
This is not a final version but a draft for the code review. 
What is implemented:
- HTCGridConnector supports multiple concurrent sessions
- Each session is an open session with the ability to add more tasks 
- Wait on tasks completion with one session, wait on all sessions completion
- Callback mechanism 
- Example of the new API use
What is not implemented
- Callbacks on failed tasks
- Documentation
- Fix of the API in old examples

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [x] Refactored something and made the world a better place
