### PR TITLE
Improvements for operating under heavy DynamoDB throttling. 

### DIFF
--- a/deployment/grid/terraform/control_plane/dynamodb.tf
+++ b/deployment/grid/terraform/control_plane/dynamodb.tf
@@ -4,6 +4,7 @@
 
 module "dynamodb_table" {
   source = "terraform-aws-modules/dynamodb-table/aws"
+  version = "3.1.2"
   name   = var.ddb_state_table
 
   read_capacity  = var.dynamodb_billing_mode == "PROVISIONED" ? var.dynamodb_table_read_capacity : null

--- a/deployment/grid/terraform/control_plane/lambda.tf
+++ b/deployment/grid/terraform/control_plane/lambda.tf
@@ -442,7 +442,7 @@ resource "aws_iam_policy" "lambda_data_policy" {
         "s3:*",
         "ec2:CreateNetworkInterface",
         "ec2:DeleteNetworkInterface",
-        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeNetworkInterfaces"
       ],
       "Resource": "*",
       "Effect": "Allow"

--- a/deployment/grid/terraform/control_plane/variables.tf
+++ b/deployment/grid/terraform/control_plane/variables.tf
@@ -15,7 +15,15 @@ variable "lambda_runtime" {
 }
 
 variable "ddb_state_table" {
-  description = "HTC DynamoDB table name"
+  description = "HTC DynamoDB state table name"
+}
+
+variable "dynamodb_autoscaling_enabled" {
+  description = "Switches autoscaling for the dynamodb table"
+}
+
+variable "dynamodb_billing_mode" {
+  description = "Sets billing mode [PROVISIONED] or [PAY_PER_REQUEST]"
 }
 
 variable "sqs_queue" {

--- a/deployment/grid/terraform/main.tf
+++ b/deployment/grid/terraform/main.tf
@@ -194,6 +194,8 @@ module "control_plane" {
     error_logging_stream = local.error_logging_stream
     dynamodb_table_read_capacity = var.dynamodb_default_read_capacity
     dynamodb_table_write_capacity = var.dynamodb_default_write_capacity
+    dynamodb_billing_mode = var.dynamodb_billing_mode
+    dynamodb_autoscaling_enabled = var.dynamodb_autoscaling_enabled
     dynamodb_gsi_index_table_write_capacity = var.dynamodb_default_write_capacity
     dynamodb_gsi_index_table_read_capacity = var.dynamodb_default_read_capacity
     dynamodb_gsi_ttl_table_write_capacity = var.dynamodb_default_write_capacity

--- a/deployment/grid/terraform/variables.tf
+++ b/deployment/grid/terraform/variables.tf
@@ -69,7 +69,18 @@ variable "fluentbit_version" {
 
 variable "ddb_state_table" {
   default  = "htc_tasks_state_table"
-  description = "htc DinamoDB table name"
+  description = "htc DinamoDB state table name"
+}
+
+variable "dynamodb_autoscaling_enabled" {
+  description = "Switches autoscaling for the dynamodb table"
+  type = bool
+  default = false
+}
+
+variable "dynamodb_billing_mode" {
+  description = "Sets billing mode [PROVISIONED] or [PAY_PER_REQUEST]"
+  default = "PROVISIONED"
 }
 
 variable "task_queue_service" {

--- a/source/client/python/api-v0.1/api/connector.py
+++ b/source/client/python/api-v0.1/api/connector.py
@@ -337,6 +337,7 @@ class AWSConnector:
                 logging.warning(raw_response)
             except ApiException as e:
                 logging.error("Exception when calling DefaultApi->ca_post: %s\n" % e)
+                raise(e)
 
         logging.info("Finish submit")
         return raw_response

--- a/source/client/python/api-v0.1/api/state_table_dynamodb.py
+++ b/source/client/python/api-v0.1/api/state_table_dynamodb.py
@@ -16,7 +16,7 @@ import traceback
 
 
 from utils.state_table_common import TASK_STATE_CANCELLED, TASK_STATE_PENDING, TASK_STATE_FAILED,\
-    TASK_STATE_PROCESSING, TASK_STATE_RETRYING, TASK_STATE_INCONSISTENT, TASK_STATE_FINISHED, TTL_LAMBDA_ID
+    TASK_STATE_PROCESSING, TASK_STATE_FINISHED
 from utils.state_table_common import StateTableException
 
 
@@ -135,9 +135,6 @@ class StateTableDDB:
 
     def update_task_status_to_failed(self, task_id):
         self.__finalize_tasks_state(task_id, TASK_STATE_FAILED)
-
-    def update_task_status_to_inconsistent(self, task_id):
-        self.__finalize_tasks_state(task_id, TASK_STATE_INCONSISTENT)
 
     def update_task_status_to_cancelled(self, task_id):
         self.__finalize_tasks_state(task_id, TASK_STATE_CANCELLED)
@@ -599,7 +596,7 @@ class StateTableDDB:
             StateTableException on throttling
             Exception for all other errors
         """
-        if new_task_state not in [TASK_STATE_FAILED, TASK_STATE_INCONSISTENT, TASK_STATE_CANCELLED]:
+        if new_task_state not in [TASK_STATE_FAILED, TASK_STATE_CANCELLED]:
             logging.error("__finalize_tasks_state called with incorrect input: {}".format(
                 new_task_state
             ))

--- a/source/client/python/utils/utils/state_table_common.py
+++ b/source/client/python/utils/utils/state_table_common.py
@@ -8,10 +8,6 @@ TASK_STATE_PENDING = "pending"
 TASK_STATE_FAILED = "failed"
 TASK_STATE_FINISHED = "finished"
 TASK_STATE_PROCESSING = "processing"
-TASK_STATE_RETRYING = "retrying"
-TASK_STATE_INCONSISTENT = "inconsistent"
-
-TTL_LAMBDA_ID = 'TTL_LAMBDA'
 
 
 class StateTableException(Exception):

--- a/source/control_plane/python/lambda/cancel_tasks/cancel_tasks.py
+++ b/source/control_plane/python/lambda/cancel_tasks/cancel_tasks.py
@@ -11,7 +11,7 @@ import traceback
 
 import utils.grid_error_logger as errlog
 
-from utils.state_table_common import TASK_STATE_PENDING, TASK_STATE_PROCESSING, TASK_STATE_RETRYING, StateTableException
+from utils.state_table_common import TASK_STATE_PENDING, TASK_STATE_PROCESSING, StateTableException
 
 client = boto3.client('dynamodb')
 dynamodb = boto3.resource('dynamodb')
@@ -22,7 +22,7 @@ state_table = state_table_manager(
     os.environ['STATE_TABLE_CONFIG'],
     os.environ['STATE_TABLE_NAME'])
 
-task_states_to_cancel = [TASK_STATE_RETRYING, TASK_STATE_PENDING, TASK_STATE_PROCESSING]
+task_states_to_cancel = [TASK_STATE_PENDING, TASK_STATE_PROCESSING]
 
 
 def cancel_tasks_by_status(session_id, task_state):

--- a/source/control_plane/python/lambda/ttl_checker/ttl_checker.py
+++ b/source/control_plane/python/lambda/ttl_checker/ttl_checker.py
@@ -6,14 +6,14 @@ import logging
 import boto3
 import time
 import os
+from datetime import datetime, timedelta
 
 from botocore.exceptions import ClientError
-from boto3.dynamodb.conditions import Key, Attr
 
 from utils.performance_tracker import EventsCounter, performance_tracker_initializer
 from utils import grid_error_logger as errlog
 
-from utils.state_table_common import TASK_STATE_RETRYING, TASK_STATE_INCONSISTENT, TASK_STATE_FAILED
+from utils.state_table_common import TASK_STATE_RETRYING, TASK_STATE_INCONSISTENT, TASK_STATE_FAILED, StateTableException
 from api.queue_manager import queue_manager
 
 region = os.environ["REGION"]
@@ -42,6 +42,7 @@ dlq = queue_manager(
     tasks_queue_name=os.environ['TASKS_QUEUE_DLQ_NAME'],
     region=region)
 
+cw_client = boto3.client('cloudwatch')
 
 TTL_LAMBDA_ID = 'TTL_LAMBDA'
 TTL_LAMBDA_TMP_STATE = TASK_STATE_RETRYING
@@ -49,6 +50,8 @@ TTL_LAMBDA_FAILED_STATE = TASK_STATE_FAILED
 TTL_LAMBDA_INCONSISTENT_STATE = TASK_STATE_INCONSISTENT
 MAX_RETRIES = 5
 RETRIEVE_EXPIRED_TASKS_LIMIT = 200
+
+STATE_TABLE_THROTTLING_LIMIT_FOR_MEASURED_PERIOD = 1000
 
 
 # TODO: implement archival after 10 days in S3
@@ -65,70 +68,57 @@ def lambda_handler(event, context):
     """
     stats_obj = {'01_invocation_tstmp': {"label": "None", "tstmp": int(round(time.time() * 1000))}}
     event_counter = EventsCounter(
-        ["counter_expired_tasks", "counter_failed_to_acquire",
-         "counter_failed_tasks", "counter_released_tasks", "counter_inconsistent_state", "counter_tasks_queue_size"])
+        ["counter_expired_tasks",
+         "counter_failed_tasks", "counter_retried_tasks", "counter_retried_tasks_vto_reset_fail"
+         "counter_tasks_queue_size",
+         "counter_skip_check_under_throttling"])
 
-    for expired_tasks in state_table.query_expired_tasks():
+    # <1.> If State Table is throttling we are skipping TTL checks.
+    if is_state_table_under_throttling():
+      logging.warning("State Table experiencing throttling, skipping TTL checking for this cycle")
+      event_counter.increment("counter_skip_check_under_throttling", 1)
 
-        event_counter.increment("counter_expired_tasks", len(expired_tasks))
-        event_counter.increment("counter_tasks_queue_size", queue.get_queue_length())
+    else:
 
-        for item in expired_tasks:
-            print("Processing expired task: {}".format(item))
-            task_id = item.get('task_id')
-            owner_id = item.get('task_owner')
-            current_heartbeat_timestamp = item.get('heartbeat_expiration_timestamp')
-            try:
-                is_acquired = state_table.acquire_task_for_ttl_lambda(
-                    task_id, owner_id, current_heartbeat_timestamp)
+      for expired_tasks in state_table.query_expired_tasks():
 
-                if not is_acquired:
-                    # task has been updated at the very last second...
-                    event_counter.increment("counter_failed_to_acquire")
-                    continue
+          event_counter.increment("counter_expired_tasks", len(expired_tasks))
+          event_counter.increment("counter_tasks_queue_size", queue.get_queue_length())
 
-                # retreive current number of retries and task message handler
-                retries, task_handler_id, task_priority = retreive_retries_and_task_handler_and_priority(task_id)
-                print("Number of retires for task[{}]: {} Priority: {}".format(task_id, retries, task_priority))
-                print("Last owner for task [{}]: {}".format(task_id, owner_id))
+          for item in expired_tasks:
+              print("Processing expired task: {}".format(item))
+              task_id = item.get('task_id')
+              owner_id = item.get('task_owner')
 
-                # TODO: MAX_RETRIES should be extracted from task definition... Store in DDB?
-                if retries == MAX_RETRIES:
-                    print("Failing task {} after {} retries".format(task_id, retries))
-                    event_counter.increment("counter_failed_tasks")
-                    fail_task(task_id, task_handler_id, task_priority)
-                    continue
+              # retreive current number of retries and task message handler
+              retries, task_sqs_handler_id, task_priority = retreive_retries_and_task_handler_and_priority(task_id)
+              print(f"Number of retires for task[{task_id}]: {retries} Priority: {task_priority}")
+              print(f"Last owner for task [{task_id}]: {owner_id}")
 
-                event_counter.increment("counter_released_tasks")
-                # else
-                state_table.retry_task(task_id, retries + 1)
+
+              if retries == MAX_RETRIES:
+                  # TODO: MAX_RETRIES should be extracted from task definition... Store in DDB?
+                  print(f"Failing task {task_id} after {retries} retries")
+                  event_counter.increment("counter_failed_tasks")
+                  fail_task(task_id, task_sqs_handler_id, task_priority)
+                  continue
+
+
+              if do_retry_task(task_id, retries + 1):
+                event_counter.increment("counter_retried_tasks")
 
                 try:
-                    # Task can be acquired by an agent from this point
-                    reset_task_msg_vto(task_handler_id, task_priority)
-                    print("SUCCESS FIX for {}".format(task_id))
+                  reset_task_msg_vto(task_sqs_handler_id, task_priority)
+                  print("SUCCESS FIX for {}".format(task_id))
 
-                except ClientError:
+                except ClientError as e:
+                    print(e.response)
+                    event_counter.increment("counter_retried_tasks_vto_reset_fail")
+                    logging.warning("Could not reset VTO on a task that is being retried, continue...")
 
-                    try:
-                        errlog.log('Failed to reset VTO trying to delete: {} '.format(task_id))
-                        delete_message_from_queue(task_handler_id)
-                    except ClientError:
-                        errlog.log('Inconsistent task: {} sending do DLQ'.format(task_id))
-                        event_counter.increment("counter_inconsistent_state")
-                        set_task_inconsistent(task_id)
-                        send_to_dlq(item)
-
-            except ClientError as e:
-                errlog.log('Lambda ttl error: {}'.format(e.response['Error']['Message']))
-                print("Cannot process task {} : {}".format(task_id, e))
-                print("Sending task {} to DLQ...".format(task_id))
-                send_to_dlq(item)
-            except Exception as e:
-                print("Cannot process task {} : {}".format(task_id, e))
-                print("Sending task {} to DLQ...".format(task_id))
-                errlog.log('Lambda ttl error: {}'.format(e))
-                send_to_dlq(item)
+                except Exception as e:
+                  errlog.log(f"TTL Lambda unexpected error during VTO reset: [{task_id}] [{e}]")
+                  raise e
 
     stats_obj['02_completion_tstmp'] = {"label": "ttl_execution_time", "tstmp": int(round(time.time() * 1000))}
     perf_tracker.add_metric_sample(
@@ -139,13 +129,81 @@ def lambda_handler(event, context):
     )
     perf_tracker.submit_measurements()
 
+def is_state_table_under_throttling():
+    """This function checks DynamoDB metrics in cloud watch to detect throttling events
 
-def fail_task(task_id, task_handler_id, task_priority):
+    Returns:
+      True if number of UpdateItem throttling events above defined threshold
+
+    """
+
+    response = cw_client.get_metric_statistics(
+      Namespace="AWS/DynamoDB",
+      MetricName="ThrottledRequests",
+      Dimensions=[
+          {
+              "Name": "TableName",
+              "Value": "htc_tasks_state_table-ddbtest"
+
+          },
+          {
+              "Name": "Operation",
+              "Value" : "UpdateItem"
+          }
+      ],
+      StartTime=datetime.utcnow() - timedelta(seconds = (1*60)),
+      EndTime=datetime.utcnow(),
+      Period=60,
+      Statistics=[
+          "Sum"
+      ],
+      Unit='Count'
+    )
+
+    throttling_events = 0
+    for datapoint in response['Datapoints']:
+        throttling_events += datapoint['Sum']
+    print(f"Throttling events observed : {throttling_events} \
+      allowed limit: {STATE_TABLE_THROTTLING_LIMIT_FOR_MEASURED_PERIOD}")
+
+    return throttling_events > STATE_TABLE_THROTTLING_LIMIT_FOR_MEASURED_PERIOD
+
+def do_retry_task(task_id, new_retry_count):
+  """This function attempts to re-try a task in the State Table.
+
+  The most common way to not being able to perform the re-try is when the task has been
+  already completed by the worker. There is always a raice condition here. Occurs more often when
+  state table is throttling.
+
+  Returns:
+    True/False on success or failure
+
+  """
+  try:
+
+    state_table.retry_task(task_id, new_retry_count)
+    return True
+
+  except StateTableException as e:
+
+    if e.caused_by_condition:
+      logging.warning(f"TTL Checker can not reset task [{task_id}] due to condition error. \
+        Perhaps task has been finished by the worker. Skipping task")
+      return False
+    elif e.caused_by_throttling:
+      logging.warning(f"TTL Checker can not claim Task [{task_id}] due to DynamoDB throtling. \
+        Skipping task")
+      return False
+  except Exception as e:
+    errlog.log(f"Unexpected error in retrying task [{task_id}] by TTL Checker. Raising exception {e}")
+    raise e
+
+def fail_task(task_id, task_sqs_handler_id, task_priority):
     """This function set the task_status of task to fail
 
     Args:
       task_id(str): the id of the task to update
-      task_handler_id(str): the task handler associated to this task
+      task_sqs_handler_id(str): the task handler associated to this task
       task_priority(int): the priority of the task.
 
     Returns:
@@ -156,7 +214,7 @@ def fail_task(task_id, task_handler_id, task_priority):
 
     """
     try:
-      delete_message_from_queue(task_handler_id, task_priority)
+      delete_message_from_queue(task_sqs_handler_id, task_priority)
 
       state_table.update_task_status_to_failed(task_id)
 
@@ -165,33 +223,11 @@ def fail_task(task_id, task_handler_id, task_priority):
       raise e
 
 
-def set_task_inconsistent(task_id):
-    """This function set the task_status of task to inconsistent
-
-    Args:
-      task_id(str): the id of the task to update
-
-    Returns:
-      Nothing
-
-    Raises:
-      ClientError: if DynamoDB table cannot be updated
-
-    """
-    try:
-
-        state_table.update_task_status_to_inconsistent(task_id)
-
-    except ClientError as e:
-        errlog.log("Cannot set task to inconsistent {} : {}".format(task_id, e))
-        raise e
-
-
-def delete_message_from_queue(task_handler_id, task_priority):
+def delete_message_from_queue(task_sqs_handler_id, task_priority):
     """This function delete the message from the task queue
 
     Args:
-      task_handler_id(str): the task handler associated of the message to be deleted
+      task_sqs_handler_id(str): the task handler associated of the message to be deleted
       task_priority(int): priority of the task
 
     Returns:
@@ -203,13 +239,10 @@ def delete_message_from_queue(task_handler_id, task_priority):
     """
 
     try:
-        queue.delete_message(task_handler_id, task_priority)
+        queue.delete_message(task_sqs_handler_id, task_priority)
     except ClientError as e:
-        errlog.log("Cannot delete message {} : {}".format(task_handler_id, e))
+        errlog.log("Cannot delete message {} : {}".format(task_sqs_handler_id, e))
         raise e
-
-
-
 
 
 def retreive_retries_and_task_handler_and_priority(task_id):
@@ -227,12 +260,13 @@ def retreive_retries_and_task_handler_and_priority(task_id):
       ClientError: if DynamoDB query failed
 
     """
+
     try:
 
         resp_task = state_table.get_task_by_id(task_id)
-        # CHeck if 1 and only 1
+
         return resp_task.get('retries'),\
-               resp_task.get('task_handler_id'),\
+               resp_task.get('sqs_handler_id'),\
                resp_task.get('task_priority')
 
     except ClientError as e:
@@ -259,9 +293,7 @@ def reset_task_msg_vto(handler_id, task_priority):
         raise e
 
 
-
-
-def send_to_dlq(task):
+def send_to_dlq(item):
     """
 
     Args:
@@ -270,5 +302,11 @@ def send_to_dlq(task):
     Returns:
 
     """
-    logging.warning(f"Sending task [{task}] to DLQ")
-    dlq.send_message(message_bodies=[str(task)])
+    logging.warning(f"Sending task [{item}] to DLQ")
+
+    messages = [{
+        'Id': item.get('task_id'),
+        'MessageBody': str(item)
+    }]
+
+    dlq.send_messages(message_bodies=messages)


### PR DESCRIPTION
### Description

This pull request incorporates a number of changes & fixes around HTC-Grid operating under heavy DynamoDB throttling.
Changes to TTL Lambda
- Intermediate state TTL_LAMBDA has been deprecated
- Failure to reset SQS VTO changed from a failure to a warning
- TTL Lambda temporary suspends TTL checks while DynamoDB under throttling allowing workers to update their tasks
Changes to DynamoDB
- DynamoDB now supports all 3 provisioning configurations: Provisioned, Provisioned + Auto Scaling, On-Demand

- Various minor fixes

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ x (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [x] Refactored something and made the world a better place
