### PR TITLE
ci: fix scanning workflows failing on deprecated actions/upload-artifact@v3

### DIFF
--- a/.github/conf/tflint.hcl
+++ b/.github/conf/tflint.hcl
@@ -1,7 +1,7 @@
 config {
   format = "sarif"
 
-  module = false
+  call_module_type = "none"
   force = false
   disabled_by_default = false
 }

--- a/.github/workflows/cfn_scan.yaml
+++ b/.github/workflows/cfn_scan.yaml
@@ -44,7 +44,7 @@ jobs:
           sarif_file: "${{ env.CFN_LINT_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CFN_LINT_REPORT_FILE }}
           path: ${{ env.CFN_LINT_REPORT_FILE }}
@@ -78,7 +78,7 @@ jobs:
           sarif_file: "${{ env.CFN_NAG_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CFN_NAG_REPORT_FILE }}
           path: ${{ env.CFN_NAG_REPORT_FILE }}

--- a/.github/workflows/doc_builder.yaml
+++ b/.github/workflows/doc_builder.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout mainline
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: 'main'
 

--- a/.github/workflows/iac_scan.yaml
+++ b/.github/workflows/iac_scan.yaml
@@ -48,7 +48,7 @@ jobs:
           sarif_file: "${{ env.TRIVY_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TRIVY_REPORT_FILE }}
           path: ${{ env.TRIVY_REPORT_FILE }}
@@ -82,7 +82,7 @@ jobs:
           sarif_file: "${{ env.CHECKOV_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHECKOV_REPORT_FILE }}
           path: ${{ env.CHECKOV_REPORT_FILE }}
@@ -129,7 +129,7 @@ jobs:
           sarif_file: "${{ env.TFLINT_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TFLINT_REPORT_FILE }}
           path: ${{ env.TFLINT_REPORT_FILE }}

--- a/.github/workflows/py_scan.yaml
+++ b/.github/workflows/py_scan.yaml
@@ -41,7 +41,7 @@ jobs:
           sarif_file: "${{ env.BANDIT_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BANDIT_REPORT_FILE }}
           path: ${{ env.BANDIT_REPORT_FILE }}
@@ -75,7 +75,7 @@ jobs:
           sarif_file: "${{ env.FLAKE8_REPORT_FILE }}"
 
       - name: Save report results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.FLAKE8_REPORT_FILE }}
           path: ${{ env.FLAKE8_REPORT_FILE }}


### PR DESCRIPTION
### Description

The security/lint scanning workflows were **hard-failing on every PR at the "Set up job" step**, before any scan ran, because GitHub [retired `actions/upload-artifact@v3`](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) — any workflow still referencing it fails immediately during setup. This PR fixes the pipeline.

**Changes**

1. **Bump deprecated actions** (commit `230b136`)
   - `actions/upload-artifact@v3` → `@v4` in `py_scan.yaml` (bandit, flake8), `cfn_scan.yaml` (cfn-lint, cfn_nag), and `iac_scan.yaml` (trivy, checkov, tflint) — 7 usages.
   - `actions/checkout@v2` → `@v4` in `doc_builder.yaml` (deprecated Node runtime).
   - *Safe bump:* v4 forbids two uploads sharing an artifact name within a run; here every upload is in its own job with a unique name (`BANDIT_REPORT_FILE`, `FLAKE8_REPORT_FILE`, …), so the constraint doesn't apply. No `download-artifact` usage exists.

2. **Fix tflint config** (commit `6b8212d`)
   - Once the jobs could run again, `tflint` failed on `tflint --init` with *"module attribute was removed in v0.54.0, use call_module_type instead"* (the action pulls `tflint_version: latest`).
   - Replaced `module = false` with `call_module_type = "none"` in `.github/conf/tflint.hcl` — the documented migration, preserving behavior (don't inspect called child modules).

**Result:** all 28 checks pass (bandit, flake8, cfn-lint, cfn_nag, checkov, trivy, tflint, tfchecks, CodeQL, Analyze, EasyCLA).

**Out of scope (warnings only, not failing):** `github/codeql-action/upload-sarif@v2` deprecation and the Node-20 actions (`checkout@v3`, `setup-tflint@v3`) — a follow-up sweep if desired.

### Checklist
- [ ] Added tests that cover your change (if possible) <!-- N/A: CI-config only, no application code -->
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory) <!-- N/A: no docs impact -->
- [x] Manually tested <!-- verified all 28 checks green on this PR after both fixes -->
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [ ] Refactored something and made the world a better place
